### PR TITLE
This commit provides a comprehensive overhaul of the project's struct…

### DIFF
--- a/cflex/CMakeLists.txt
+++ b/cflex/CMakeLists.txt
@@ -47,7 +47,7 @@ target_include_directories(cflex_build PUBLIC src/cflex_build)
 set_source_files_properties(src/cflex_build/internal/cflex_platform.c PROPERTIES HEADER_FILE_ONLY ON)
 
 # Organize build tool files in the IDE to mirror the directory structure
-source_group(TREE ${CMAKE_CURRENT_SOURCE_DIR}/src/cflex_build PREFIX "Source" FILES ${TOOL_SOURCE_FILES})
+source_group(TREE ${CMAKE_CURRENT_SOURCE_DIR}/src/cflex_build PREFIX "source" FILES ${TOOL_SOURCE_FILES})
 
 
 # --- Generated files ---
@@ -95,9 +95,9 @@ target_include_directories(program PRIVATE
 add_dependencies(program generate_reflection)
 
 # Organize application and library files in the IDE to mirror the directory structure
-source_group(TREE ${CMAKE_CURRENT_SOURCE_DIR}/src/program PREFIX "Source" FILES ${PROGRAM_SOURCE_FILES})
-source_group(TREE ${CMAKE_CURRENT_SOURCE_DIR}/src/cflex PREFIX "Source/Library" FILES ${LIB_SOURCE_FILES})
-source_group("Generated" FILES ${GENERATED_C})
+source_group(TREE ${CMAKE_CURRENT_SOURCE_DIR}/src/program PREFIX "source" FILES ${PROGRAM_SOURCE_FILES})
+source_group(TREE ${CMAKE_CURRENT_SOURCE_DIR}/src/cflex PREFIX "source/library" FILES ${LIB_SOURCE_FILES})
+source_group("generated" FILES ${GENERATED_C})
 
 
 # --- Optional: Installation ---


### PR DESCRIPTION
…ure and CMake build system to improve maintainability, clarity, and developer experience.

Key changes include:

1.  **CMake Refactoring:**
    - Replaced manual file listings with `file(GLOB_RECURSE)` to automatically discover source files.
    - Re-organized the IDE project view using `source_group` with `PREFIX` to create a clean, lowercase folder structure for handwritten (`source/`, `source/library/`) and generated (`generated/`) files.
    - Implemented a robust, portable script to redirect all build outputs (executables, libraries) to a top-level `bin/` and `lib/` directory.

2.  **Source Directory Refactoring:**
    - Introduced a new `internal/` subdirectory convention for files that are part of a unity build (i.e., included directly by other `.c` files).
    - Moved `cflex_platform.c` into `cflex_build/internal/`.
    - Created `cflex/internal/cflex_parser.c` as a placeholder.
    - Updated the source code (`#include`) to reflect the new file locations.

3.  **Documentation:**
    - Updated `AGENTS.md` to document the new `internal/` directory convention.