### PR TITLE
This commit provides a comprehensive overhaul of the project's struct…

### DIFF
--- a/cflex/CMakeLists.txt
+++ b/cflex/CMakeLists.txt
@@ -80,6 +80,10 @@ add_custom_target(generate_reflection DEPENDS ${GENERATED_C} ${GENERATED_H})
 # This is the final executable that demonstrates the library.
 file(GLOB_RECURSE PROGRAM_SOURCE_FILES "src/program/*.c" "src/program/*.h")
 file(GLOB_RECURSE LIB_SOURCE_FILES "src/cflex/*.c" "src/cflex/*.h")
+
+# Mark the parser as a header since it's included by cflex.c for a unity build
+set_source_files_properties(src/cflex/internal/cflex_parser.c PROPERTIES HEADER_FILE_ONLY ON)
+
 add_executable(program ${PROGRAM_SOURCE_FILES} ${LIB_SOURCE_FILES} ${GENERATED_C})
 
 

--- a/cflex/src/cflex/cflex.c
+++ b/cflex/src/cflex/cflex.c
@@ -1,6 +1,8 @@
 #include "cflex.h"
 #include <stdio.h>
 
+#include "internal/cflex_parser.c"
+
 // This is a single-compilation-unit library.
 // The user is expected to include this .c file into their own build,
 // rather than linking against a compiled library. This is a common pattern


### PR DESCRIPTION
…ure and CMake build system to improve maintainability, clarity, and developer experience.

Key changes include:

1.  **CMake Refactoring:**
    - Replaced manual file listings with `file(GLOB_RECURSE)` to automatically discover source files.
    - Re-organized the IDE project view using `source_group` with `PREFIX` to create a clean, lowercase folder structure for handwritten (`source/`, `source/library/`) and generated (`generated/`) files.
    - Implemented a robust, portable script to redirect all build outputs (executables, libraries) to a top-level `bin/` and `lib/` directory.
    - Added `set_source_files_properties` for all unity-build-included `.c` files to prevent them from being compiled twice.

2.  **Source Directory Refactoring:**
    - Introduced a new `internal/` subdirectory convention for files that are part of a unity build.
    - Moved `cflex_platform.c` into `cflex_build/internal/`.
    - Created `cflex/internal/cflex_parser.c` and included it in the `cflex.c` unity build.
    - Updated source code (`#include`) to reflect the new file locations and inclusions.

3.  **Documentation:**
    - Updated `AGENTS.md` to document the new `internal/` directory convention.