### PR TITLE
refactor: Encapsulate generated data from public API

### DIFF
--- a/cflex/src/cflex/cflex.c
+++ b/cflex/src/cflex/cflex.c
@@ -1,6 +1,15 @@
 #include "cflex.h"
 #include <string.h>
 
+// These global variables are defined in the generated source file and
+// discovered by the linker.
+extern const cf_type_t* cf_type_array[];
+extern const int32_t cf_type_count;
+// The generated header is not included here, so we don't know the enum type.
+// We use a simple integer for the public API.
+extern const int32_t CF_TYPE_ID_COUNT;
+
+
 const cf_type_t* cf_find_type_by_name(const char* name)
 {
     if (!name)
@@ -20,9 +29,12 @@ const cf_type_t* cf_find_type_by_name(const char* name)
     return NULL;
 }
 
-const cf_type_t* cf_find_type_by_id(cf_type_id_t id)
+const cf_type_t* cf_find_type_by_id(int32_t id)
 {
-    if (id >= 0 && id < CF_TYPE_ID_COUNT)
+    // We can't use the enum count directly, so we rely on cf_type_count
+    // for bounds checking. A better implementation might have the count
+    // in the generated file match exactly. For now, this is safe.
+    if (id >= 0 && id < cf_type_count)
     {
         return cf_type_array[id];
     }

--- a/cflex/src/cflex/cflex.h
+++ b/cflex/src/cflex/cflex.h
@@ -87,16 +87,11 @@ typedef struct cf_type_t
 } cf_type_t;
 
 
-// --- Global Data ---
-// These are defined in the generated cflex_generated.c file.
-extern const cf_type_t* cf_type_array[];
-extern const int32_t cf_type_count;
-
-#include "cflex_generated.h"
-
 // --- Library API ---
-// These are implemented in cflex.c.
+// These are implemented in cflex.c. The global data they access is
+// provided at link time by a generated source file.
+
 const cf_type_t* cf_find_type_by_name(const char* name);
-const cf_type_t* cf_find_type_by_id(cf_type_id_t id);
+const cf_type_t* cf_find_type_by_id(int32_t id);
 
 #endif // CFLEX_H

--- a/cflex/src/program/program.c
+++ b/cflex/src/program/program.c
@@ -1,5 +1,6 @@
 #include "cflex.h"
 #include "program.h"
+#include "cflex_generated.h" // User code includes the generated header for type IDs
 #include <stdio.h>
 
 void print_type_details(const cf_type_t* type)


### PR DESCRIPTION
Refactors the library architecture to provide a clean separation between the runtime library and the build-time generated code, following a design pattern similar to UE4's reflection system.

Key changes:
- `cflex.h` no longer includes `cflex_generated.h` or exposes the global `cf_type_array`. It now provides a pure API.
- The `cf_find_type_by_id` function signature was changed to use `int32_t` to keep the API decoupled from the generated `cf_type_id_t` enum.
- `cflex.c` now uses `extern` to get access to the generated data at link time.
- User code (e.g., `program.c`) is now responsible for including both `cflex.h` for the API and `cflex_generated.h` for the generated type IDs.

This change results in a much cleaner and more robust API, hiding implementation details from the end-user. The project builds and runs correctly with this new architecture.