### PR TITLE
Refactor the cflex library to use a header/implementation pair of fil…

### DIFF
--- a/cflex/CMakeLists.txt
+++ b/cflex/CMakeLists.txt
@@ -112,7 +112,10 @@ add_dependencies(program generate_reflection)
 
 # --- IDE File Organization ---
 # We still want to see the library and generated files in the IDE.
-set(LIB_HEADER_FILES src/cflex/cflex.h)
+set(LIB_HEADER_FILES
+    src/cflex/cflex.h
+    src/cflex/cflex_implementation.h
+)
 
 # Organize application and library files in the IDE to mirror the directory structure
 source_group(TREE ${CMAKE_CURRENT_SOURCE_DIR}/src/program PREFIX "source" FILES ${PROGRAM_SOURCE_FILES})

--- a/cflex/src/cflex/cflex.h
+++ b/cflex/src/cflex/cflex.h
@@ -84,35 +84,4 @@ typedef struct cf_type_t {
 const cf_type_t *cf_find_type_by_name(const char *name);
 const cf_type_t *cf_find_type_by_id(cf_type_id_t id);
 
-#ifdef CFLEX_IMPLEMENTATION
-
-#include <string.h>
-
-// The generated source file is included here to provide the reflection data.
-#include "cflex_generated.c"
-
-const cf_type_t *cf_find_type_by_name(const char *name) {
-  if (!name) {
-    return NULL;
-  }
-
-  for (int32_t i = 0; i < cf_type_count; ++i) {
-    const cf_type_t *type = cf_type_array[i];
-    if (type && type->name && strcmp(name, type->name) == 0) {
-      return type;
-    }
-  }
-
-  return NULL;
-}
-
-const cf_type_t *cf_find_type_by_id(cf_type_id_t id) {
-  if (id >= 0 && id < CF_TYPE_ID_COUNT) {
-    return cf_type_array[id];
-  }
-  return NULL;
-}
-
-#endif // CFLEX_IMPLEMENTATION
-
 #endif // CFLEX_H

--- a/cflex/src/cflex/cflex_implementation.h
+++ b/cflex/src/cflex/cflex_implementation.h
@@ -1,0 +1,32 @@
+#ifndef CFLEX_IMPLEMENTATION_H
+#define CFLEX_IMPLEMENTATION_H
+
+#include "cflex.h"
+#include <string.h>
+
+// The generated source file is included here to provide the reflection data.
+#include "cflex_generated.c"
+
+const cf_type_t *cf_find_type_by_name(const char *name) {
+  if (!name) {
+    return NULL;
+  }
+
+  for (int32_t i = 0; i < cf_type_count; ++i) {
+    const cf_type_t *type = cf_type_array[i];
+    if (type && type->name && strcmp(name, type->name) == 0) {
+      return type;
+    }
+  }
+
+  return NULL;
+}
+
+const cf_type_t *cf_find_type_by_id(cf_type_id_t id) {
+  if (id >= 0 && id < CF_TYPE_ID_COUNT) {
+    return cf_type_array[id];
+  }
+  return NULL;
+}
+
+#endif // CFLEX_IMPLEMENTATION_H

--- a/cflex/src/program/program.c
+++ b/cflex/src/program/program.c
@@ -1,6 +1,6 @@
-#define CFLEX_IMPLEMENTATION
 #include "cflex.h"
 #include "program.h"
+#include "cflex_implementation.h"
 #include <stdio.h>
 
 void print_type_details(const cf_type_t* type)


### PR DESCRIPTION
…es (`cflex.h` and `cflex_implementation.h`).

This change is based on user feedback to separate the public API from the implementation details, making the main `cflex.h` header cleaner and easier to read for library consumers.

- `cflex.h` now contains only the public API declarations and data structures.
- `cflex_implementation.h` contains the function implementations and is intended to be included in a single source file in the user's project.

The example program and build system have been updated to reflect this new design.