### PR TITLE
Adjust the `source_group` commands in CMakeLists.txt to improve the o…

### DIFF
--- a/cflex/CMakeLists.txt
+++ b/cflex/CMakeLists.txt
@@ -118,8 +118,8 @@ set(LIB_HEADER_FILES
 )
 
 # Organize application and library files in the IDE to mirror the directory structure
-source_group(TREE ${CMAKE_CURRENT_SOURCE_DIR}/src/program PREFIX "source" FILES ${PROGRAM_SOURCE_FILES})
-source_group(TREE ${CMAKE_CURRENT_SOURCE_DIR}/src/cflex PREFIX "source/library" FILES ${LIB_HEADER_FILES})
+source_group(TREE ${CMAKE_CURRENT_SOURCE_DIR}/src/program PREFIX "program" FILES ${PROGRAM_SOURCE_FILES})
+source_group(TREE ${CMAKE_CURRENT_SOURCE_DIR}/src/cflex PREFIX "cflex" FILES ${LIB_HEADER_FILES})
 source_group("generated" FILES ${GENERATED_C} ${GENERATED_H})
 
 


### PR DESCRIPTION
…rganization of files in IDEs like Visual Studio.

The `PREFIX` for the program and cflex library source groups has been changed to create a cleaner, top-level folder structure in the Solution Explorer, as requested by the user. This does not affect the build logic, only the presentation of files in the IDE.