### PR TITLE
Add the cflex library header files to the `program` executable's sour…

### DIFF
--- a/cflex/CMakeLists.txt
+++ b/cflex/CMakeLists.txt
@@ -95,7 +95,7 @@ target_include_directories(cflex INTERFACE
 # This is the final executable that demonstrates the library.
 file(GLOB_RECURSE PROGRAM_SOURCE_FILES "src/program/*.c" "src/program/*.h")
 
-add_executable(program ${PROGRAM_SOURCE_FILES})
+add_executable(program ${PROGRAM_SOURCE_FILES} ${LIB_HEADER_FILES})
 
 # The program needs to include headers from its own source directory.
 target_include_directories(program PRIVATE src/program)


### PR DESCRIPTION
…ce list.

This ensures that IDEs like Visual Studio recognize the headers as part of the project, allowing them to be displayed in the Solution Explorer and organized by the `source_group` command.

This fixes an issue where the header files were not visible in the IDE project view.