### PR TITLE
Add the generated include directory path directly to the `program` ta…

### DIFF
--- a/cflex/CMakeLists.txt
+++ b/cflex/CMakeLists.txt
@@ -110,9 +110,14 @@ add_executable(program
     ${GENERATED_FILES}
 )
 
-# The program only needs to include headers from its own source directory.
-# The other necessary include paths will be inherited from the cflex library.
-target_include_directories(program PRIVATE src/program)
+# The program needs to include headers from its own source directory.
+# We also redundantly add the generated directory here to work around a common
+# Visual Studio IntelliSense quirk where it doesn't correctly inherit
+# include paths from INTERFACE libraries for live analysis.
+target_include_directories(program PRIVATE
+    src/program
+    ${GENERATED_DIR}
+)
 
 # Link the program against the cflex library. This transitively applies the
 # include directories from cflex to the program, which is a more robust way

--- a/cflex/src/cflex/cflex_implementation.h
+++ b/cflex/src/cflex/cflex_implementation.h
@@ -5,7 +5,8 @@
 #include <string.h>
 
 // The generated source file is included here to provide the reflection data.
-#include "cflex_generated.c"
+// Using angle brackets as a hint to the IDE to search the include paths.
+#include <cflex_generated.c>
 
 // Include internal implementation files (unity build style).
 #include "internal/cflex_parser.h"


### PR DESCRIPTION
…rget, in addition to it being an INTERFACE property of the `cflex` library.

This redundancy is a targeted workaround for a common quirk in the Visual Studio CMake project generator, where IntelliSense does not correctly inherit include paths from INTERFACE libraries for header files that are part of a target's source list.

This change ensures that IntelliSense can find the generated headers from any file in the project, while maintaining the semantically correct modern CMake structure.