### PR TITLE
Refactor build process to a single pass and add debug mode

### DIFF
--- a/cflex/src/cflex_build/cflex_build.c
+++ b/cflex/src/cflex_build/cflex_build.c
@@ -37,49 +37,62 @@ main( int argc, char** argv )
     const char* module_name         = "cflex";
     bool        include_default_types = false;
 
-    // --- Argument Parsing ---
-    int arg_idx = 1;
-    while ( arg_idx < argc )
+    // If no command-line arguments are provided, assume debug mode for IDEs.
+    if ( argc == 1 )
     {
-        const char* arg = argv[ arg_idx ];
-        if ( strcmp( arg, "--name" ) == 0 )
+        print_fmt( "--- No arguments provided, running in debug mode with hardcoded paths. ---\n" );
+        input_path          = "F:/C/cflex/cflex/src/program";
+        output_path         = "F:/C/cflex/cflex/build/cflex_generated";
+        module_name         = "program";
+        include_default_types = true;    // Typically you'd want this for an executable.
+    }
+    else
+    {
+        // --- Argument Parsing for command-line use ---
+        int arg_idx = 1;
+        while ( arg_idx < argc )
         {
-            if ( arg_idx + 1 < argc )
+            const char* arg = argv[ arg_idx ];
+            if ( strcmp( arg, "--name" ) == 0 )
             {
-                module_name = argv[ arg_idx + 1 ];
-                arg_idx += 2;
+                if ( arg_idx + 1 < argc )
+                {
+                    module_name = argv[ arg_idx + 1 ];
+                    arg_idx += 2;
+                }
+                else
+                {
+                    file_print_fmt( stderr, "Error: --name requires an argument.\n" );
+                    return 1;
+                }
+            }
+            else if ( strcmp( arg, "--include-default-types" ) == 0 )
+            {
+                include_default_types = true;
+                arg_idx++;
             }
             else
             {
-                file_print_fmt( stderr, "Error: --name requires an argument.\n" );
-                return 1;
+                if ( !input_path )
+                {
+                    input_path = arg;
+                }
+                else if ( !output_path )
+                {
+                    output_path = arg;
+                }
+                arg_idx++;
             }
-        }
-        else if ( strcmp( arg, "--include-default-types" ) == 0 )
-        {
-            include_default_types = true;
-            arg_idx++;
-        }
-        else
-        {
-            if ( !input_path )
-            {
-                input_path = arg;
-            }
-            else if ( !output_path )
-            {
-                output_path = arg;
-            }
-            arg_idx++;
         }
     }
 
     if ( !input_path || !output_path )
     {
-        file_print_fmt(
-            stderr,
-            "Usage: %s <input_path> <output_path> [--name <module_name>] [--include-default-types]\n",
-            argv[ 0 ] );
+        file_print_fmt( stderr,
+                        "Usage: %s <input_path> <output_path> [--name <module_name>] "
+                        "[--include-default-types]\n"
+                        "Or run with no arguments for a debug session with hardcoded paths.\n",
+                        argv[ 0 ] );
         return 1;
     }
 


### PR DESCRIPTION
Previously, the build system would invoke the `cflex_build` tool twice for each executable. This has been refactored to a single pass.

This commit introduces the following changes:
1.  Modifies the `cflex_build` tool to accept an `--include-default-types` flag, allowing it to generate both default and user-defined types in a single run.
2.  Introduces an `add_cflex_target` CMake function to abstract the build logic. This function passes the `--include-default-types` flag only when building executables.
3.  Adds a debug mode to `cflex_build`. When run with no arguments (e.g., from an IDE), it uses hardcoded paths to facilitate debugging.
4.  Cleans up application and unit test code to remove now-redundant function calls and includes from the old two-pass system.